### PR TITLE
Update app.css

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -2378,7 +2378,7 @@ ul.link-list li a .icon {
   scroll-snap-align: left;
   scroll-snap-stop: always;
   overscroll-behavior: auto;
-  flex-basis: min(100vw, 360px);
+  flex-basis: min(500px, 100%);
   flex-shrink: 0;
   box-shadow: -1px 0 var(--bg-color), -2px 0 var(--drop-shadow-color),
     -3px 0 var(--bg-color);


### PR DESCRIPTION
Fixed misaligned viewpoint width on columns being too narrow when using Multi-Column on mobiles. This also improves better readability on desktop too. By default zoom on both Chrome for PC and Android is set to 100%


**Image showing PWA installed on Android with default zoom 100%, causing misaligned columns, forcing to change 150% to correct, but font texts get too large**

https://everythingbagel.social/@shadow/112293826234220698

[Link posted to Mastodon with #mastoadmin for feedback ](https://everythingbagel.social/@shadow/112295951920327884) and [video recording](https://everythingbagel.social/@shadow/112295710805994173)